### PR TITLE
== to is

### DIFF
--- a/FiniteDifferences_ShortleyWeller_SquareGrid.py
+++ b/FiniteDifferences_ShortleyWeller_SquareGrid.py
@@ -260,7 +260,7 @@ class FiniteDifferences_ShortleyWeller_SquareGrid(PyPIC_Scatter_Gather):
     #@profile    
 	def solve(self, rho = None, flag_verbose = False):
 
-		if rho == None:
+		if rho is None:
 			rho = self.rho
 		self._solve_core(self, rho)
 


### PR DESCRIPTION
On Arch Linux, this already raises an error and PyECLOUD crashes.