### PR TITLE
Fix mirroring index bug in FFT_OpenBoundary.py

### DIFF
--- a/FFT_OpenBoundary.py
+++ b/FFT_OpenBoundary.py
@@ -99,9 +99,9 @@ class FFT_OpenBoundary(PyPIC_Scatter_Gather):
         fgreen = np.zeros((2 * ny, 2 * nx))
         # Integration and circular Green's function
         fgreen[:ny, :nx] = tmpfgreen[1:, 1:] + tmpfgreen[:-1, :-1] - tmpfgreen[1:, :-1] - tmpfgreen[:-1, 1:]
-        fgreen[ny:, :nx] = fgreen[ny:0:-1, :nx]
-        fgreen[:ny, nx:] = fgreen[:ny, nx:0:-1]
-        fgreen[ny:, nx:] = fgreen[ny:0:-1, nx:0:-1]
+        fgreen[ny:, :nx] = fgreen[ny-1::-1, :nx]
+        fgreen[:ny, nx:] = fgreen[:ny, nx-1::-1]
+        fgreen[ny:, nx:] = fgreen[ny-1::-1, nx-1::-1]
 
         self.fgreen = fgreen
         self.fgreentr = np.fft.fft2(fgreen).copy()


### PR DESCRIPTION
analogous to https://github.com/PyCOMPLETE/PyPIC/commit/4de07d52a25b0dd96256b20f04f4f97c4bdde6b4

In the mirror methods, the indexing was off by one:
e.g. to mirror the part from 0 to 4 in the np.arange(10) array, one would need to 

```python
a = np.arange(10)
a[5:] = a[5-1::-1] # giving a == [0,1,2,3,4,4,3,2,1,0]
```

and it was (offset by 1):
```python
a[5:] = a[5:0:-1] # giving a == [0,1,2,3,4,5,4,3,2,1]
```